### PR TITLE
Fix ExtNotification signature to match ExtNotificationHandler interface

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -117,7 +117,7 @@ func (c *AgentSideConnection) ExtMethod(ctx context.Context, method string, para
 }
 
 // ExtNotification sends a custom extension notification to the client.
-func (c *AgentSideConnection) ExtNotification(ctx context.Context, method string, params any) error {
+func (c *AgentSideConnection) ExtNotification(ctx context.Context, method string, params json.RawMessage) error {
 	return c.conn.SendNotification(ctx, method, params)
 }
 

--- a/client.go
+++ b/client.go
@@ -115,7 +115,7 @@ func (c *ClientSideConnection) ExtMethod(ctx context.Context, method string, par
 	return c.conn.SendRequest(ctx, method, params)
 }
 
-func (c *ClientSideConnection) ExtNotification(ctx context.Context, method string, params any) error {
+func (c *ClientSideConnection) ExtNotification(ctx context.Context, method string, params json.RawMessage) error {
 	return c.conn.SendNotification(ctx, method, params)
 }
 


### PR DESCRIPTION
## Summary
- Change `params any` to `params json.RawMessage` on `AgentSideConnection.ExtNotification` and `ClientSideConnection.ExtNotification`
- This makes both types satisfy the `ExtNotificationHandler` interface, which requires `params json.RawMessage`

## Test plan
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)