### PR TITLE
Fix SessionCapabilities missing fork/resume/close fields

### DIFF
--- a/.schema.yaml
+++ b/.schema.yaml
@@ -1,0 +1,13 @@
+package: acp
+ignoreErrors: true
+
+targets:
+  - input: schema/schema.json
+    meta: schema/meta.json
+    output: schema.gen.go
+
+  - input: schema/schema.unstable.json
+    meta: schema/meta.unstable.json
+    output: schema.gen.unstable.go
+    excludeFrom: schema/schema.json
+    excludeMetaFrom: schema/meta.json

--- a/.schema.yaml
+++ b/.schema.yaml
@@ -5,6 +5,7 @@ targets:
   - input: schema/schema.json
     meta: schema/meta.json
     output: schema.gen.go
+    mergePropertiesFrom: schema/schema.unstable.json
 
   - input: schema/schema.unstable.json
     meta: schema/meta.unstable.json

--- a/agent.go
+++ b/agent.go
@@ -117,7 +117,7 @@ func (c *AgentSideConnection) ExtMethod(ctx context.Context, method string, para
 }
 
 // ExtNotification sends a custom extension notification to the client.
-func (c *AgentSideConnection) ExtNotification(ctx context.Context, method string, params any) error {
+func (c *AgentSideConnection) ExtNotification(ctx context.Context, method string, params json.RawMessage) error {
 	return c.conn.SendNotification(ctx, method, params)
 }
 

--- a/client.go
+++ b/client.go
@@ -115,7 +115,7 @@ func (c *ClientSideConnection) ExtMethod(ctx context.Context, method string, par
 	return c.conn.SendRequest(ctx, method, params)
 }
 
-func (c *ClientSideConnection) ExtNotification(ctx context.Context, method string, params any) error {
+func (c *ClientSideConnection) ExtNotification(ctx context.Context, method string, params json.RawMessage) error {
 	return c.conn.SendNotification(ctx, method, params)
 }
 

--- a/internal/cmd/schema/config.go
+++ b/internal/cmd/schema/config.go
@@ -13,8 +13,9 @@ type Target struct {
 	InputFile   string `yaml:"input"`       // Path to input JSON schema file
 	MetaFile    string `yaml:"meta"`        // Path to meta.json file (optional)
 	OutputFile  string `yaml:"output"`      // Path to output Go file
-	ExcludeFrom     string `yaml:"excludeFrom"`     // Path to base schema; identical definitions are skipped
-	ExcludeMetaFrom string `yaml:"excludeMetaFrom"` // Path to base meta; identical constants are skipped
+	ExcludeFrom         string `yaml:"excludeFrom"`         // Path to base schema; identical definitions are skipped
+	ExcludeMetaFrom     string `yaml:"excludeMetaFrom"`     // Path to base meta; identical constants are skipped
+	MergePropertiesFrom string `yaml:"mergePropertiesFrom"` // Path to extended schema; new properties on existing types are merged in
 }
 
 // Config holds configuration for schema generation
@@ -22,8 +23,9 @@ type Config struct {
 	InputFile    string   `yaml:"input"`        // Path to input JSON schema file (single target, legacy)
 	MetaFile     string   `yaml:"meta"`         // Path to meta.json file (single target, legacy)
 	OutputFile   string   `yaml:"output"`       // Path to output Go file (single target, legacy)
-	ExcludeFrom     string `yaml:"-"` // Path to base schema to exclude definitions from
-	ExcludeMetaFrom string `yaml:"-"` // Path to base meta to exclude constants from
+	ExcludeFrom         string `yaml:"-"` // Path to base schema to exclude definitions from
+	ExcludeMetaFrom     string `yaml:"-"` // Path to base meta to exclude constants from
+	MergePropertiesFrom string `yaml:"-"` // Path to extended schema to merge new properties from
 	PackageName     string `yaml:"package"` // Go package name for generated code
 	IgnoreErrors bool     `yaml:"ignoreErrors"` // Skip definitions that cause generation errors
 	IgnoreTypes  []string `yaml:"ignoreTypes"`  // List of type names to ignore during generation
@@ -125,6 +127,9 @@ func LoadConfigFromFile(configPath string) (*Config, error) {
 		}
 		if config.Targets[i].ExcludeMetaFrom != "" && !filepath.IsAbs(config.Targets[i].ExcludeMetaFrom) {
 			config.Targets[i].ExcludeMetaFrom = filepath.Join(configDir, config.Targets[i].ExcludeMetaFrom)
+		}
+		if config.Targets[i].MergePropertiesFrom != "" && !filepath.IsAbs(config.Targets[i].MergePropertiesFrom) {
+			config.Targets[i].MergePropertiesFrom = filepath.Join(configDir, config.Targets[i].MergePropertiesFrom)
 		}
 	}
 

--- a/internal/cmd/schema/generator.go
+++ b/internal/cmd/schema/generator.go
@@ -56,6 +56,16 @@ func (g *Generator) LoadSchema() error {
 	}
 	g.schema = schema
 
+	// Merge additional properties from extended schema if configured.
+	// This allows the base target to pick up new properties that the
+	// extended schema adds to types already defined in the base schema
+	// (e.g., unstable properties on stable types).
+	if g.config.MergePropertiesFrom != "" {
+		if err := g.mergeExtendedProperties(); err != nil {
+			return fmt.Errorf("failed to merge properties from extended schema: %w", err)
+		}
+	}
+
 	// Build exclude set from base schema if configured
 	if g.config.ExcludeFrom != "" {
 		if err := g.loadExcludedDefs(); err != nil {
@@ -78,6 +88,37 @@ func (g *Generator) loadExcludedDefs() error {
 	for name := range baseSchema.Defs {
 		g.excludedDefNames[name] = true
 	}
+	return nil
+}
+
+// mergeExtendedProperties loads an extended schema (e.g., the unstable schema)
+// and merges any new properties it defines on types that also exist in the base
+// schema. This allows the base output to include fields added by the extended
+// schema without requiring manual edits to the generated file.
+func (g *Generator) mergeExtendedProperties() error {
+	extSchema, err := jsondef.LoadSchema(g.config.MergePropertiesFrom)
+	if err != nil {
+		return err
+	}
+
+	for name, extDef := range extSchema.Defs {
+		baseDef, exists := g.schema.Defs[name]
+		if !exists {
+			// Type only exists in extended schema; not our concern here.
+			continue
+		}
+		if extDef.Properties == nil || baseDef.Properties == nil {
+			continue
+		}
+		// Merge any properties from the extended def that are not in the base def.
+		for propName, propSchema := range extDef.Properties {
+			if _, alreadyExists := baseDef.Properties[propName]; !alreadyExists {
+				baseDef.Properties[propName] = propSchema
+				fmt.Printf("Merged property %q from extended schema into %s\n", propName, name)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/cmd/schema/generator.go
+++ b/internal/cmd/schema/generator.go
@@ -34,7 +34,8 @@ type Generator struct {
 	builder          *astgen.FileBuilder
 	generatedCode    []byte
 	skippedItems     []string
-	excludedDefNames map[string]bool // definitions to exclude (from base schema)
+	excludedDefNames map[string]bool   // definitions to exclude (from base schema)
+	baseSchema       *jsondef.Schema   // base schema for comparing union variants
 }
 
 // NewGenerator creates a new generator instance.
@@ -71,6 +72,7 @@ func (g *Generator) loadExcludedDefs() error {
 	if err != nil {
 		return err
 	}
+	g.baseSchema = baseSchema
 
 	g.excludedDefNames = make(map[string]bool, len(baseSchema.Defs))
 	for name := range baseSchema.Defs {
@@ -102,6 +104,20 @@ func (g *Generator) Generate() error {
 
 	for _, definition := range definitions {
 		if g.isTypeIgnored(definition.Name) {
+			// For excluded discriminated unions, check if the current schema
+			// has new variants not present in the base schema. If so, generate
+			// only the new variant wrapper structs and their marker methods.
+			if g.baseSchema != nil && definition.Type == jsondef.ComplexStruct {
+				defName := definition.Name
+				definition.Name = toTitleCase(definition.Name)
+				if err := g.generateExtendedUnionVariants(definition); err != nil {
+					if g.config.IgnoreErrors {
+						fmt.Printf("Warning: Skipping extended variants for %s: %v\n", defName, err)
+					} else {
+						return fmt.Errorf("failed to generate extended variants for %s: %w", defName, err)
+					}
+				}
+			}
 			g.addSkippedItem(definition.Name)
 			continue
 		}
@@ -599,6 +615,126 @@ func (g *Generator) generateComplexStruct(name string, schema *jsondef.Schema) e
 	return nil
 }
 
+// generateExtendedUnionVariants generates only the new variant structs and marker
+// methods for a discriminated union that exists in the base schema but has
+// additional variants in the current (unstable) schema. It also generates an
+// init() function that registers the new variants for deserialization.
+func (g *Generator) generateExtendedUnionVariants(def jsondef.Definition) error {
+	schema := def.Schema
+	baseDef, baseExists := g.baseSchema.Defs[strings.ToLower(def.Name[:1])+def.Name[1:]]
+	if !baseExists {
+		// Try the original name before title-casing
+		for name, s := range g.baseSchema.Defs {
+			if toTitleCase(name) == def.Name {
+				baseDef = s
+				baseExists = true
+				break
+			}
+		}
+	}
+	if !baseExists {
+		return nil // Not in base schema, nothing to extend
+	}
+
+	// Only extend if the base definition is also a discriminated union (ComplexStruct).
+	// If the base type is e.g. a Ref/alias, it doesn't have the variant registry.
+	baseDefined := jsondef.Classify("", baseDef)
+	if baseDefined.Type != jsondef.ComplexStruct {
+		return nil
+	}
+
+	// Determine discriminator field
+	allVariants := make([]*jsondef.Schema, 0, len(schema.AnyOf)+len(schema.OneOf))
+	allVariants = append(allVariants, schema.AnyOf...)
+	allVariants = append(allVariants, schema.OneOf...)
+
+	var discriminatorField string
+	if schema.Discriminator != nil && schema.Discriminator.PropertyName != "" {
+		discriminatorField = schema.Discriminator.PropertyName
+	} else {
+		discriminatorField = jsondef.DetectDiscriminator(allVariants)
+	}
+	if discriminatorField == "" {
+		return nil
+	}
+
+	// Collect base variant discriminator values
+	baseAllVariants := make([]*jsondef.Schema, 0, len(baseDef.AnyOf)+len(baseDef.OneOf))
+	baseAllVariants = append(baseAllVariants, baseDef.AnyOf...)
+	baseAllVariants = append(baseAllVariants, baseDef.OneOf...)
+	baseDiscValues := make(map[string]bool)
+	for _, v := range baseAllVariants {
+		if v.Properties != nil {
+			if dp, ok := v.Properties[discriminatorField]; ok && dp.Const != nil {
+				if val, ok := dp.Const.StringValue(); ok {
+					baseDiscValues[val] = true
+				}
+			}
+		}
+	}
+
+	// Filter to only new variants
+	var newVariants []*jsondef.Schema
+	for _, v := range allVariants {
+		if v.Properties != nil {
+			if dp, ok := v.Properties[discriminatorField]; ok && dp.Const != nil {
+				if val, ok := dp.Const.StringValue(); ok {
+					if !baseDiscValues[val] {
+						newVariants = append(newVariants, v)
+					}
+				}
+			}
+		}
+	}
+
+	if len(newVariants) == 0 {
+		return nil
+	}
+
+	// Generate the new variant structs and marker methods
+	name := def.Name
+	markerMethodName := "is" + name + "Variant"
+	variants := g.collectVariants(name, schema, newVariants, discriminatorField)
+
+	for _, v := range variants {
+		methodSrc := fmt.Sprintf(`func (%s) %s() string { return "%s" }`,
+			v.TypeName, markerMethodName, v.DiscValue)
+		fn, err := astgen.CreateMethodFromSource(methodSrc)
+		if err != nil {
+			return fmt.Errorf("failed to create marker method for %s: %w", v.TypeName, err)
+		}
+		g.builder.AddDecl(fn)
+	}
+
+	// Generate init() function to register new variants
+	g.builder.AddImport("encoding/json")
+	var registrations []string
+	for _, v := range variants {
+		registrations = append(registrations,
+			fmt.Sprintf(`	Register%sVariant("%s", func(data []byte) (%sVariant, error) {
+		var v %s
+		if err := json.Unmarshal(data, &v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	})`, name, v.DiscValue, strings.ToLower(name[:1])+name[1:], v.TypeName))
+	}
+
+	initSrc := fmt.Sprintf("func init() {\n%s\n}", strings.Join(registrations, "\n"))
+	decls, err := astgen.CreateDeclsFromSource(initSrc)
+	if err != nil {
+		return fmt.Errorf("failed to create init function: %w", err)
+	}
+	for _, d := range decls {
+		g.builder.AddDecl(d)
+	}
+
+	// Generate As* accessor methods for the new variants
+	g.generateAccessors(name, variants)
+
+	return nil
+}
+
 func (g *Generator) collectVariants(parentName string, _ *jsondef.Schema, allVariants []*jsondef.Schema, discriminatorField string) []OneOfVariant {
 	var variants []OneOfVariant
 
@@ -821,8 +957,18 @@ func (g *Generator) generateUnmarshalJSON(typeName string, variants []OneOfVaria
 		return nil`, v.DiscValue, v.TypeName, recv))
 	}
 
-	// Add default case
-	defaultCase := fmt.Sprintf(`	return fmt.Errorf("unknown discriminator value: %%s", disc.%s)`, discFieldName)
+	// Add default case: try extension registry first, then fall back
+	markerName := strings.ToLower(typeName[:1]) + typeName[1:] + "Variant"
+	registryFn := "try" + typeName + "Extension"
+	defaultCase := fmt.Sprintf(`	if fn, ok := %s(disc.%s); ok {
+			v, err := fn(data)
+			if err != nil {
+				return err
+			}
+			%s.variant = v
+			return nil
+		}
+		return fmt.Errorf("unknown discriminator value: %%s", disc.%s)`, registryFn, discFieldName, recv, discFieldName)
 	if defaultVariant != nil {
 		defaultCase = fmt.Sprintf(`	var v %s
 		if err := json.Unmarshal(data, &v); err != nil {
@@ -830,6 +976,11 @@ func (g *Generator) generateUnmarshalJSON(typeName string, variants []OneOfVaria
 		}
 		%s.variant = v
 		return nil`, defaultVariant.TypeName, recv)
+	}
+
+	// Generate the extension registry types and functions for this union
+	if defaultVariant == nil {
+		g.generateVariantRegistry(typeName, markerName, registryFn)
 	}
 
 	src := fmt.Sprintf(`func (%s *%s) UnmarshalJSON(data []byte) error {
@@ -852,6 +1003,45 @@ func (g *Generator) generateUnmarshalJSON(typeName string, variants []OneOfVaria
 		return
 	}
 	g.builder.AddDecl(fn)
+}
+
+// generateVariantRegistry generates the extension registry for a discriminated union.
+// This allows new variants to be registered at init time (e.g., from unstable schema).
+func (g *Generator) generateVariantRegistry(typeName, markerName, lookupFn string) {
+	registerFn := "Register" + typeName + "Variant"
+	factoryType := typeName + "VariantFactory"
+	registryVar := strings.ToLower(typeName[:1]) + typeName[1:] + "ExtVariants"
+
+	src := fmt.Sprintf(`// %s is a factory function that deserializes a variant from JSON.
+type %s func(data []byte) (%s, error)
+
+var %s = map[string]%s{}
+
+// %s registers a new variant factory for the %s union.
+// Call this from init() to extend the union with additional variants.
+func %s(discriminator string, factory %s) {
+	%s[discriminator] = factory
+}
+
+func %s(discriminator string) (%s, bool) {
+	fn, ok := %s[discriminator]
+	return fn, ok
+}`, factoryType, factoryType, markerName,
+		registryVar, factoryType,
+		registerFn, typeName,
+		registerFn, factoryType,
+		registryVar,
+		lookupFn, factoryType,
+		registryVar)
+
+	decls, err := astgen.CreateDeclsFromSource(src)
+	if err != nil {
+		fmt.Printf("Warning: failed to generate variant registry for %s: %v\n", typeName, err)
+		return
+	}
+	for _, d := range decls {
+		g.builder.AddDecl(d)
+	}
 }
 
 func (g *Generator) generateAccessors(typeName string, variants []OneOfVariant) {

--- a/internal/cmd/schema/main.go
+++ b/internal/cmd/schema/main.go
@@ -132,14 +132,15 @@ func executeGenerate(_ context.Context, cmd *cli.Command) error {
 	targets := config.GetTargets()
 	for _, target := range targets {
 		targetConfig := &Config{
-			InputFile:       target.InputFile,
-			MetaFile:        target.MetaFile,
-			OutputFile:      target.OutputFile,
-			ExcludeFrom:     target.ExcludeFrom,
-			ExcludeMetaFrom: target.ExcludeMetaFrom,
-			PackageName:     config.PackageName,
-			IgnoreErrors:    config.IgnoreErrors,
-			IgnoreTypes:     config.IgnoreTypes,
+			InputFile:           target.InputFile,
+			MetaFile:            target.MetaFile,
+			OutputFile:          target.OutputFile,
+			ExcludeFrom:         target.ExcludeFrom,
+			ExcludeMetaFrom:     target.ExcludeMetaFrom,
+			MergePropertiesFrom: target.MergePropertiesFrom,
+			PackageName:         config.PackageName,
+			IgnoreErrors:        config.IgnoreErrors,
+			IgnoreTypes:         config.IgnoreTypes,
 		}
 
 		if err := generateTarget(targetConfig); err != nil {

--- a/match.go
+++ b/match.go
@@ -17,6 +17,7 @@ type SessionUpdateMatcher[T any] struct {
 	CurrentModeUpdate       func(SessionUpdateCurrentModeUpdate) T
 	ConfigOptionUpdate      func(SessionUpdateConfigOptionUpdate) T
 	SessionInfoUpdate       func(SessionUpdateSessionInfoUpdate) T
+	UsageUpdate             func(SessionUpdateUsageUpdate) T
 	Default                 func() T
 }
 
@@ -84,6 +85,12 @@ func MatchSessionUpdate[T any](u *SessionUpdate, m SessionUpdateMatcher[T]) T {
 			return m.SessionInfoUpdate(v)
 		}
 		return matchDefault(m.Default, "SessionInfoUpdate")
+	}
+	if v, ok := u.AsUsageUpdate(); ok {
+		if m.UsageUpdate != nil {
+			return m.UsageUpdate(v)
+		}
+		return matchDefault(m.Default, "UsageUpdate")
 	}
 	panic("SessionUpdate has no variant set")
 }

--- a/schema.ext.go
+++ b/schema.ext.go
@@ -104,6 +104,14 @@ func NewSessionUpdateSessionInfoUpdate(title string, updatedAt string) SessionUp
 	}}
 }
 
+// NewSessionUpdateUsageUpdate creates a SessionUpdate with a usage update.
+func NewSessionUpdateUsageUpdate(usage UsageUpdate) SessionUpdate {
+	return SessionUpdate{variant: SessionUpdateUsageUpdate{
+		UsageUpdate:   usage,
+		SessionUpdate: "usage_update",
+	}}
+}
+
 // --- ContentBlock constructors ---
 
 // NewContentBlockText creates a text content block.

--- a/schema.gen.go
+++ b/schema.gen.go
@@ -1011,6 +1011,7 @@ type CancelNotification struct {
 // See protocol docs: [Client Capabilities](https://agentclientprotocol.com/protocol/initialization#client-capabilities)
 type ClientCapabilities struct {
 	Meta     map[string]any          `json:"_meta,omitempty"`
+	Auth     *AuthCapabilities       `json:"auth,omitempty"`
 	FS       *FileSystemCapabilities `json:"fs,omitempty"`
 	Terminal bool                    `json:"terminal,omitempty"`
 }
@@ -1029,8 +1030,9 @@ type Content struct {
 
 // A streamed item of content
 type ContentChunk struct {
-	Meta    map[string]any `json:"_meta,omitempty"`
-	Content ContentBlock   `json:"content"`
+	Meta      map[string]any `json:"_meta,omitempty"`
+	Content   ContentBlock   `json:"content"`
+	MessageID string         `json:"messageId,omitempty"`
 }
 
 // Request to create a new terminal and execute a command.
@@ -1200,6 +1202,7 @@ type LoadSessionRequest struct {
 type LoadSessionResponse struct {
 	Meta          map[string]any        `json:"_meta,omitempty"`
 	ConfigOptions []SessionConfigOption `json:"configOptions,omitempty"`
+	Models        *SessionModelState    `json:"models,omitempty"`
 	Modes         *SessionModeState     `json:"modes,omitempty"`
 }
 
@@ -1250,6 +1253,7 @@ type NewSessionRequest struct {
 type NewSessionResponse struct {
 	Meta          map[string]any        `json:"_meta,omitempty"`
 	ConfigOptions []SessionConfigOption `json:"configOptions,omitempty"`
+	Models        *SessionModelState    `json:"models,omitempty"`
 	Modes         *SessionModeState     `json:"modes,omitempty"`
 	SessionID     SessionID             `json:"sessionId"`
 }
@@ -1312,6 +1316,7 @@ type PromptCapabilities struct {
 // See protocol docs: [User Message](https://agentclientprotocol.com/protocol/prompt-turn#1-user-message)
 type PromptRequest struct {
 	Meta      map[string]any `json:"_meta,omitempty"`
+	MessageID string         `json:"messageId,omitempty"`
 	Prompt    []ContentBlock `json:"prompt"`
 	SessionID SessionID      `json:"sessionId"`
 }
@@ -1320,8 +1325,10 @@ type PromptRequest struct {
 //
 // See protocol docs: [Check for Completion](https://agentclientprotocol.com/protocol/prompt-turn#4-check-for-completion)
 type PromptResponse struct {
-	Meta       map[string]any `json:"_meta,omitempty"`
-	StopReason StopReason     `json:"stopReason"`
+	Meta          map[string]any `json:"_meta,omitempty"`
+	StopReason    StopReason     `json:"stopReason"`
+	Usage         *Usage         `json:"usage,omitempty"`
+	UserMessageID string         `json:"userMessageId,omitempty"`
 }
 
 // Request to read content from a text file.
@@ -1399,8 +1406,11 @@ type SelectedPermissionOutcome struct {
 //
 // See protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/initialization#session-capabilities)
 type SessionCapabilities struct {
-	Meta map[string]any           `json:"_meta,omitempty"`
-	List *SessionListCapabilities `json:"list,omitempty"`
+	Meta   map[string]any             `json:"_meta,omitempty"`
+	Close  *SessionCloseCapabilities  `json:"close,omitempty"`
+	Fork   *SessionForkCapabilities   `json:"fork,omitempty"`
+	List   *SessionListCapabilities   `json:"list,omitempty"`
+	Resume *SessionResumeCapabilities `json:"resume,omitempty"`
 }
 
 // A session configuration option selector and its current state.

--- a/schema.gen.go
+++ b/schema.gen.go
@@ -183,6 +183,9 @@ const (
 	ToolKindOther ToolKind = "other"
 )
 
+type AgentResponse any
+type ClientResponse any
+
 // Text content. May be plain text or formatted with Markdown.
 //
 // All agents MUST support text content blocks in prompts.
@@ -268,6 +271,21 @@ func (c ContentBlock) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(c.variant)
 }
+
+// ContentBlockVariantFactory is a factory function that deserializes a variant from JSON.
+type ContentBlockVariantFactory func(data []byte) (contentBlockVariant, error)
+
+var contentBlockExtVariants = map[string]ContentBlockVariantFactory{}
+
+// RegisterContentBlockVariant registers a new variant factory for the ContentBlock union.
+// Call this from init() to extend the union with additional variants.
+func RegisterContentBlockVariant(discriminator string, factory ContentBlockVariantFactory) {
+	contentBlockExtVariants[discriminator] = factory
+}
+func tryContentBlockExtension(discriminator string) (ContentBlockVariantFactory, bool) {
+	fn, ok := contentBlockExtVariants[discriminator]
+	return fn, ok
+}
 func (c *ContentBlock) UnmarshalJSON(data []byte) error {
 	var disc struct {
 		Type string `json:"type"`
@@ -312,6 +330,14 @@ func (c *ContentBlock) UnmarshalJSON(data []byte) error {
 		c.variant = v
 		return nil
 	default:
+		if fn, ok := tryContentBlockExtension(disc.Type); ok {
+			v, err := fn(data)
+			if err != nil {
+				return err
+			}
+			c.variant = v
+			return nil
+		}
 		return fmt.Errorf("unknown discriminator value: %s", disc.Type)
 	}
 }
@@ -457,6 +483,21 @@ func (r RequestPermissionOutcome) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(r.variant)
 }
+
+// RequestPermissionOutcomeVariantFactory is a factory function that deserializes a variant from JSON.
+type RequestPermissionOutcomeVariantFactory func(data []byte) (requestPermissionOutcomeVariant, error)
+
+var requestPermissionOutcomeExtVariants = map[string]RequestPermissionOutcomeVariantFactory{}
+
+// RegisterRequestPermissionOutcomeVariant registers a new variant factory for the RequestPermissionOutcome union.
+// Call this from init() to extend the union with additional variants.
+func RegisterRequestPermissionOutcomeVariant(discriminator string, factory RequestPermissionOutcomeVariantFactory) {
+	requestPermissionOutcomeExtVariants[discriminator] = factory
+}
+func tryRequestPermissionOutcomeExtension(discriminator string) (RequestPermissionOutcomeVariantFactory, bool) {
+	fn, ok := requestPermissionOutcomeExtVariants[discriminator]
+	return fn, ok
+}
 func (r *RequestPermissionOutcome) UnmarshalJSON(data []byte) error {
 	var disc struct {
 		Outcome string `json:"outcome"`
@@ -480,6 +521,14 @@ func (r *RequestPermissionOutcome) UnmarshalJSON(data []byte) error {
 		r.variant = v
 		return nil
 	default:
+		if fn, ok := tryRequestPermissionOutcomeExtension(disc.Outcome); ok {
+			v, err := fn(data)
+			if err != nil {
+				return err
+			}
+			r.variant = v
+			return nil
+		}
 		return fmt.Errorf("unknown discriminator value: %s", disc.Outcome)
 	}
 }
@@ -606,6 +655,21 @@ func (s SessionUpdate) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(s.variant)
 }
+
+// SessionUpdateVariantFactory is a factory function that deserializes a variant from JSON.
+type SessionUpdateVariantFactory func(data []byte) (sessionUpdateVariant, error)
+
+var sessionUpdateExtVariants = map[string]SessionUpdateVariantFactory{}
+
+// RegisterSessionUpdateVariant registers a new variant factory for the SessionUpdate union.
+// Call this from init() to extend the union with additional variants.
+func RegisterSessionUpdateVariant(discriminator string, factory SessionUpdateVariantFactory) {
+	sessionUpdateExtVariants[discriminator] = factory
+}
+func trySessionUpdateExtension(discriminator string) (SessionUpdateVariantFactory, bool) {
+	fn, ok := sessionUpdateExtVariants[discriminator]
+	return fn, ok
+}
 func (s *SessionUpdate) UnmarshalJSON(data []byte) error {
 	var disc struct {
 		SessionUpdate string `json:"sessionUpdate"`
@@ -685,6 +749,14 @@ func (s *SessionUpdate) UnmarshalJSON(data []byte) error {
 		s.variant = v
 		return nil
 	default:
+		if fn, ok := trySessionUpdateExtension(disc.SessionUpdate); ok {
+			v, err := fn(data)
+			if err != nil {
+				return err
+			}
+			s.variant = v
+			return nil
+		}
 		return fmt.Errorf("unknown discriminator value: %s", disc.SessionUpdate)
 	}
 }
@@ -779,6 +851,21 @@ func (t ToolCallContent) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(t.variant)
 }
+
+// ToolCallContentVariantFactory is a factory function that deserializes a variant from JSON.
+type ToolCallContentVariantFactory func(data []byte) (toolCallContentVariant, error)
+
+var toolCallContentExtVariants = map[string]ToolCallContentVariantFactory{}
+
+// RegisterToolCallContentVariant registers a new variant factory for the ToolCallContent union.
+// Call this from init() to extend the union with additional variants.
+func RegisterToolCallContentVariant(discriminator string, factory ToolCallContentVariantFactory) {
+	toolCallContentExtVariants[discriminator] = factory
+}
+func tryToolCallContentExtension(discriminator string) (ToolCallContentVariantFactory, bool) {
+	fn, ok := toolCallContentExtVariants[discriminator]
+	return fn, ok
+}
 func (t *ToolCallContent) UnmarshalJSON(data []byte) error {
 	var disc struct {
 		Type string `json:"type"`
@@ -809,6 +896,14 @@ func (t *ToolCallContent) UnmarshalJSON(data []byte) error {
 		t.variant = v
 		return nil
 	default:
+		if fn, ok := tryToolCallContentExtension(disc.Type); ok {
+			v, err := fn(data)
+			if err != nil {
+				return err
+			}
+			t.variant = v
+			return nil
+		}
 		return fmt.Errorf("unknown discriminator value: %s", disc.Type)
 	}
 }

--- a/schema.gen.unstable.go
+++ b/schema.gen.unstable.go
@@ -2,6 +2,37 @@
 
 package acp
 
+import (
+	"encoding/json"
+)
+
+// **UNSTABLE**
+//
+// This capability is not part of the spec yet, and may be removed or changed at any point.
+//
+// Context window and cost update for the session.
+type SessionUpdateUsageUpdate struct {
+	UsageUpdate
+	SessionUpdate string `json:"sessionUpdate"`
+}
+
+func (SessionUpdateUsageUpdate) isSessionUpdateVariant() string {
+	return "usage_update"
+}
+func init() {
+	RegisterSessionUpdateVariant("usage_update", func(data []byte) (sessionUpdateVariant, error) {
+		var v SessionUpdateUsageUpdate
+		if err := json.Unmarshal(data, &v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	})
+}
+func (s *SessionUpdate) AsUsageUpdate() (SessionUpdateUsageUpdate, bool) {
+	v, ok := s.variant.(SessionUpdateUsageUpdate)
+	return v, ok
+}
+
 // **UNSTABLE**
 //
 // This capability is not part of the spec yet, and may be removed or changed at any point.


### PR DESCRIPTION
## Summary
- Adds `mergePropertiesFrom` config option to the schema generator, allowing a target to merge new properties from an extended schema (e.g., unstable) into types already defined in the base schema
- Configures the base target in `.schema.yaml` to merge properties from the unstable schema
- Regenerates `schema.gen.go` so `SessionCapabilities` now includes `Close`, `Fork`, and `Resume` fields (plus other unstable property extensions on existing types like `PromptResponse.Usage`, `ContentChunk.MessageId`, etc.)

Fixes #5

## Test plan
- [x] `go generate ./...` succeeds and produces correct output
- [x] `go test ./...` passes
- [x] `go vet ./...` clean

## Note
This PR depends on #4 (UsageUpdate/SessionUpdate union fix) which introduces the multi-target schema config and `excludeFrom` infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)