### PR TITLE
Fix in-flight responses dropped on EOF

### DIFF
--- a/acp_integration_test.go
+++ b/acp_integration_test.go
@@ -1,7 +1,9 @@
 package acp
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -809,4 +811,119 @@ func TestNewHelperConstructors(t *testing.T) {
 			t.Errorf("Expected ToolCallStatusPending, got %s", *status)
 		}
 	})
+}
+
+// TestEOFDoesNotDropInFlightResponses verifies that when stdin closes (EOF)
+// while a request handler is still running, the response is still written
+// to stdout before the connection shuts down.
+func TestEOFDoesNotDropInFlightResponses(t *testing.T) {
+	// Set up pipes: we write JSON-RPC requests to stdinWriter,
+	// the connection reads from stdinReader. Responses go to stdoutWriter,
+	// we read them from stdoutReader.
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+
+	handlerStarted := make(chan struct{})
+
+	// Create a connection with a handler that takes some time to respond.
+	handler := func(ctx context.Context, method string, params json.RawMessage) (any, error) {
+		if method == "initialize" {
+			close(handlerStarted)
+			// Simulate a slow handler
+			time.Sleep(100 * time.Millisecond)
+			return &InitializeResponse{
+				ProtocolVersion:   ProtocolVersion(CurrentProtocolVersion),
+				AgentCapabilities: &AgentCapabilities{LoadSession: false},
+				AuthMethods:       []AuthMethod{},
+			}, nil
+		}
+		return nil, fmt.Errorf("unknown method: %s", method)
+	}
+
+	conn := NewConnection(handler, stdinReader, stdoutWriter)
+
+	// Start the connection in a goroutine.
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- conn.Start(context.Background())
+	}()
+
+	// Send an initialize request, then immediately close stdin.
+	reqID := int64(1)
+	reqMsg := jsonRpcMessage{
+		Jsonrpc: jsonrpcVersion,
+		ID:      &reqID,
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":1,"clientCapabilities":{}}`),
+	}
+	reqData, err := json.Marshal(reqMsg)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+	reqData = append(reqData, '\n')
+
+	// Write the request.
+	if _, err := stdinWriter.Write(reqData); err != nil {
+		t.Fatalf("Failed to write request: %v", err)
+	}
+
+	// Wait for the handler to start processing, then close stdin (EOF).
+	<-handlerStarted
+	stdinWriter.Close()
+
+	// Read the response from stdout. The bug would cause this to hang
+	// or return EOF without a response.
+	responseCh := make(chan json.RawMessage, 1)
+	readErrCh := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdoutReader)
+		scanner.Buffer(make([]byte, 0, initialBufSize), maxMessageSize)
+		if scanner.Scan() {
+			data := make([]byte, len(scanner.Bytes()))
+			copy(data, scanner.Bytes())
+			responseCh <- json.RawMessage(data)
+		} else {
+			if scanner.Err() != nil {
+				readErrCh <- scanner.Err()
+			} else {
+				readErrCh <- fmt.Errorf("stdout closed (EOF) without response")
+			}
+		}
+	}()
+
+	// Wait for the response with a timeout.
+	select {
+	case resp := <-responseCh:
+		// Verify it's a valid JSON-RPC response with our request ID.
+		var msg jsonRpcMessage
+		if err := json.Unmarshal(resp, &msg); err != nil {
+			t.Fatalf("Failed to parse response: %v", err)
+		}
+		if msg.ID == nil || *msg.ID != reqID {
+			t.Fatalf("Expected response ID %d, got %v", reqID, msg.ID)
+		}
+		if msg.Error != nil {
+			t.Fatalf("Expected successful response, got error: %s", msg.Error.Message)
+		}
+		if msg.Result == nil {
+			t.Fatal("Expected result in response, got nil")
+		}
+	case readErr := <-readErrCh:
+		t.Fatalf("Failed to read response (in-flight response was dropped): %v", readErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for response — in-flight response was likely dropped")
+	}
+
+	// Verify Start returned cleanly.
+	select {
+	case err := <-startErr:
+		if err != nil {
+			t.Fatalf("Start returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for Start to return")
+	}
+
+	stdoutWriter.Close()
+	stdoutReader.Close()
 }

--- a/conn.go
+++ b/conn.go
@@ -134,7 +134,8 @@ type Connection struct {
 	writeQueue       chan jsonRpcMessage
 	ctx              context.Context
 	cancel           context.CancelFunc
-	wg               sync.WaitGroup // tracks in-flight handlers
+	wg               sync.WaitGroup // tracks writeLoop goroutine
+	handlerWg        sync.WaitGroup // tracks in-flight request/notification handlers
 	errorHandler     func(error)
 	middlewares      []Middleware
 	handler          MethodHandler // raw handler, used only during construction
@@ -271,7 +272,10 @@ func (c *Connection) Start(ctx context.Context) error {
 
 	// Start reader loop (blocks until done)
 	err := c.readLoop()
-	// Reader exited — shut down the connection
+	// Reader exited (e.g., EOF) — wait for in-flight handlers to finish
+	// so their responses get queued to the write loop before we shut down.
+	c.handlerWg.Wait()
+	// Now cancel the context to stop the write loop.
 	c.cancel()
 	return err
 }
@@ -281,10 +285,14 @@ func (c *Connection) Start(ctx context.Context) error {
 // If a shutdown timeout is configured, Close returns an error if handlers don't finish in time.
 func (c *Connection) Close() error {
 	c.cancel()
+	waitAll := func() {
+		c.handlerWg.Wait()
+		c.wg.Wait()
+	}
 	if c.shutdownTimeout > 0 {
 		done := make(chan struct{})
 		go func() {
-			c.wg.Wait()
+			waitAll()
 			close(done)
 		}()
 		select {
@@ -294,7 +302,7 @@ func (c *Connection) Close() error {
 			return fmt.Errorf("shutdown timed out after %s", c.shutdownTimeout)
 		}
 	}
-	c.wg.Wait()
+	waitAll()
 	return nil
 }
 
@@ -344,12 +352,12 @@ func (c *Connection) readLoop() error {
 
 		if msg.ID != nil && msg.Method != "" {
 			// It's a request — dispatch handler in goroutine
-			c.wg.Go(func() {
+			c.handlerWg.Go(func() {
 				c.handleRequest(msg)
 			})
 		} else if msg.Method != "" {
 			// It's a notification — dispatch handler in goroutine
-			c.wg.Go(func() {
+			c.handlerWg.Go(func() {
 				c.handleNotification(msg)
 			})
 		} else if msg.ID != nil {
@@ -377,7 +385,24 @@ func (c *Connection) writeLoop() {
 			}
 
 		case <-c.ctx.Done():
-			return
+			// Drain any remaining messages in the queue before exiting.
+			for {
+				select {
+				case msg := <-c.writeQueue:
+					data, err := json.Marshal(msg)
+					if err != nil {
+						c.logError(fmt.Errorf("failed to marshal JSON-RPC message: %w", err))
+						continue
+					}
+					// Use context.Background() since our context is cancelled.
+					if err := c.transport.WriteMessage(context.Background(), data); err != nil {
+						c.logError(fmt.Errorf("failed to write JSON-RPC message during drain: %w", err))
+						return
+					}
+				default:
+					return
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Bug**: When `readLoop` returns on EOF (stdin closed), `Start()` immediately calls `c.cancel()`, which cancels the context before in-flight request handlers can write their responses. Both `writeLoop` and `trySend` select on `c.ctx.Done()`, so responses from handlers that are still running get silently dropped.
- **Fix**: Introduces a separate `handlerWg` WaitGroup to track request/notification handler goroutines independently from the `writeLoop` goroutine. After EOF, `Start()` waits for all handlers to finish (`handlerWg.Wait()`) before cancelling the context. The `writeLoop` also drains any remaining messages from its queue on shutdown.
- **Test**: Adds `TestEOFDoesNotDropInFlightResponses` which sends a request with a slow handler, immediately closes stdin, and verifies the response is still written. Confirmed this test fails without the fix (5s timeout) and passes with it.

## Test plan

- [x] New test `TestEOFDoesNotDropInFlightResponses` reproduces the bug and verifies the fix
- [x] All existing tests pass (`go test ./...`)
- [x] Verified test fails without the fix (reverted `Start`, test times out as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)