### PR TITLE
fix: handle notifications inline to preserve ordering

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -356,10 +356,8 @@ func (c *Connection) readLoop() error {
 				c.handleRequest(msg)
 			})
 		} else if msg.Method != "" {
-			// It's a notification — dispatch handler in goroutine
-			c.handlerWg.Go(func() {
-				c.handleNotification(msg)
-			})
+			// It's a notification — handle inline to preserve ordering
+			c.handleNotification(msg)
 		} else if msg.ID != nil {
 			// It's a response — handle inline to avoid ordering issues
 			c.handleResponse(msg)


### PR DESCRIPTION
Notifications were dispatched in a goroutine via handlerWg.Go, which could reorder them relative to responses. Handle them inline instead, matching the existing inline handling for responses.

Also adds c.wg.Wait() after c.cancel() on reader EOF to ensure the write loop fully drains before the connection returns.