### PR TITLE
fix: generate discriminated union for object schemas with oneOf/anyOf

### DIFF
--- a/internal/cmd/schema/generator.go
+++ b/internal/cmd/schema/generator.go
@@ -776,7 +776,7 @@ func (g *Generator) generateExtendedUnionVariants(def jsondef.Definition) error 
 	return nil
 }
 
-func (g *Generator) collectVariants(parentName string, _ *jsondef.Schema, allVariants []*jsondef.Schema, discriminatorField string) []OneOfVariant {
+func (g *Generator) collectVariants(parentName string, parentSchema *jsondef.Schema, allVariants []*jsondef.Schema, discriminatorField string) []OneOfVariant {
 	var variants []OneOfVariant
 
 	// Check if any variant name would collide with its ref type name.
@@ -843,6 +843,35 @@ func (g *Generator) collectVariants(parentName string, _ *jsondef.Schema, allVar
 							continue
 						}
 						fields = append(fields, field)
+					}
+
+					// Include shared properties from the parent schema (e.g. id, name)
+					// so the variant struct can marshal/unmarshal the full object.
+					if parentSchema != nil && parentSchema.Properties != nil {
+						for propName, propSchema := range parentSchema.Properties {
+							if propName == discriminatorField {
+								continue
+							}
+							// Skip if the variant already defines this property.
+							if _, exists := mergedSchema.Properties[propName]; exists {
+								continue
+							}
+							// Handle _meta as generic map (same as buildStructFields).
+							if propName == "_meta" {
+								fields = append(fields, astgen.StructField{
+									Name: "Meta",
+									Type: astgen.TypeExpr("map[string]any"),
+									Tag:  `json:"_meta,omitempty"`,
+								})
+								continue
+							}
+							def := jsondef.Classify(propName, propSchema)
+							field, err := g.buildStructField(propName, propSchema, def, parentSchema)
+							if err != nil {
+								continue
+							}
+							fields = append(fields, field)
+						}
 					}
 
 					g.builder.AddDecl(astgen.StructDef(variantName, fields, desc))

--- a/internal/cmd/schema/jsondef/classify.go
+++ b/internal/cmd/schema/jsondef/classify.go
@@ -213,6 +213,12 @@ func classifyType(s *Schema) (genType GenerateType, nullable bool) {
 			if s.Properties == nil && s.AdditionalProperties != nil && s.AdditionalProperties.Schema != nil {
 				return Primitive, false
 			}
+			// An object with a discriminator + oneOf/anyOf is a discriminated union,
+			// not a plain struct. Classify as ComplexStruct so the generator produces
+			// the proper variant interface, As* accessors, and JSON marshalling.
+			if s.Discriminator != nil && (len(s.OneOf) > 0 || len(s.AnyOf) > 0) {
+				return ComplexStruct, false
+			}
 			return Struct, false
 		}
 		if defType == "array" {

--- a/schema.ext.go
+++ b/schema.ext.go
@@ -124,6 +124,21 @@ func NewSessionUpdateUsageUpdate(usage UsageUpdate) SessionUpdate {
 	}}
 }
 
+// --- SessionConfigOption constructors ---
+
+// NewSessionConfigOptionSelect creates a select-type session config option.
+func NewSessionConfigOptionSelect(id SessionConfigID, name string, currentValue SessionConfigValueID, options SessionConfigSelectOptions) SessionConfigOption {
+	return SessionConfigOption{variant: SessionConfigOptionSelect{
+		SessionConfigSelect: SessionConfigSelect{
+			CurrentValue: currentValue,
+			Options:      options,
+		},
+		Type: "select",
+		ID:   id,
+		Name: name,
+	}}
+}
+
 // --- ContentBlock constructors ---
 
 // NewContentBlockText creates a text content block.

--- a/schema.gen.go
+++ b/schema.gen.go
@@ -541,6 +541,81 @@ func (r *RequestPermissionOutcome) AsSelected() (RequestPermissionOutcomeSelecte
 	return v, ok
 }
 
+// Single-value selector (dropdown).
+type SessionConfigOptionSelect struct {
+	SessionConfigSelect
+	Type        string                       `json:"type"`
+	Description string                       `json:"description,omitempty"`
+	ID          SessionConfigID              `json:"id"`
+	Name        string                       `json:"name"`
+	Meta        map[string]any               `json:"_meta,omitempty"`
+	Category    *SessionConfigOptionCategory `json:"category,omitempty"`
+}
+
+func (SessionConfigOptionSelect) isSessionConfigOptionVariant() string {
+	return "select"
+}
+
+type sessionConfigOptionVariant interface{ isSessionConfigOptionVariant() string }
+
+// A session configuration option selector and its current state.
+type SessionConfigOption struct {
+	variant sessionConfigOptionVariant
+}
+
+func (s SessionConfigOption) MarshalJSON() ([]byte, error) {
+	if s.variant == nil {
+		return nil, fmt.Errorf("no variant is set for SessionConfigOption")
+	}
+	return json.Marshal(s.variant)
+}
+
+// SessionConfigOptionVariantFactory is a factory function that deserializes a variant from JSON.
+type SessionConfigOptionVariantFactory func(data []byte) (sessionConfigOptionVariant, error)
+
+var sessionConfigOptionExtVariants = map[string]SessionConfigOptionVariantFactory{}
+
+// RegisterSessionConfigOptionVariant registers a new variant factory for the SessionConfigOption union.
+// Call this from init() to extend the union with additional variants.
+func RegisterSessionConfigOptionVariant(discriminator string, factory SessionConfigOptionVariantFactory) {
+	sessionConfigOptionExtVariants[discriminator] = factory
+}
+func trySessionConfigOptionExtension(discriminator string) (SessionConfigOptionVariantFactory, bool) {
+	fn, ok := sessionConfigOptionExtVariants[discriminator]
+	return fn, ok
+}
+func (s *SessionConfigOption) UnmarshalJSON(data []byte) error {
+	var disc struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &disc); err != nil {
+		return err
+	}
+	switch disc.Type {
+	case "select":
+		var v SessionConfigOptionSelect
+		if err := json.Unmarshal(data, &v); err != nil {
+			return err
+		}
+		s.variant = v
+		return nil
+	default:
+		if fn, ok := trySessionConfigOptionExtension(disc.Type); ok {
+			v, err := fn(data)
+			if err != nil {
+				return err
+			}
+			s.variant = v
+			return nil
+		}
+		return fmt.Errorf("unknown discriminator value: %s", disc.Type)
+	}
+}
+func (s *SessionConfigOption) AsSelect() (SessionConfigOptionSelect, bool) {
+	v, ok := s.variant.(SessionConfigOptionSelect)
+	return v, ok
+}
+
 // Possible values for a session configuration option.
 type SessionConfigSelectOptions any
 
@@ -1411,15 +1486,6 @@ type SessionCapabilities struct {
 	Fork   *SessionForkCapabilities   `json:"fork,omitempty"`
 	List   *SessionListCapabilities   `json:"list,omitempty"`
 	Resume *SessionResumeCapabilities `json:"resume,omitempty"`
-}
-
-// A session configuration option selector and its current state.
-type SessionConfigOption struct {
-	Meta        map[string]any               `json:"_meta,omitempty"`
-	Category    *SessionConfigOptionCategory `json:"category,omitempty"`
-	Description string                       `json:"description,omitempty"`
-	ID          SessionConfigID              `json:"id"`
-	Name        string                       `json:"name"`
 }
 
 // A single-value selector (dropdown) session configuration option payload.


### PR DESCRIPTION
This fixes two issues with the schema generator:

1. **classify.go**: Objects with `discriminator` + `oneOf`/`anyOf` are now detected as `ComplexStruct` (discriminated unions) rather than plain structs.

2. **generator.go**: Shared parent properties (`id`, `name`, etc.) are now included in each variant struct so they marshal/unmarshal the full object.

Additionally regenerates `schema.gen.go` to:
- Make `SessionConfigOption` a proper discriminated union with a `SessionConfigOptionSelect` variant, enabling select-type config options.
- Remove `omitempty` from `InitializeResponse.AuthMethods` so empty slices are preserved (clients like Zed expect this field to always be present).

A helper constructor `NewSessionConfigOptionSelect` is also added in `schema.ext.go`.